### PR TITLE
Fail "skip" when input files not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ executable by the task name. The parameterised model runs are all invoked by
 the same `model` executable, so we strip the parameter off the task name to
 handle that. (Models can still get their parameter value from job environment).
 
+### The data directory
+
+Tasks should normally read and write from the self-contained workflow run
+directory, but for make-like model each new run needs access to the
+same intermediate data files, so we keep everything in an external
+data directory. For this example, create a mock input data file:
+
+```console
+$ touch /tmp/data/covid.raw
+```
+
 ### On-demand execution
 
 Install and play a new instance of the worflow each time. Cylc is designed to
@@ -115,14 +126,6 @@ restart rather then rerun from scratch if the same instance is re-played.:
 ```console
 $ cylc install demo && cylc play demo && cylc tui demo
 ```
-
-### The data directory
-
-Tasks should normally read and write from the self-contained workflow run
-directory, but for make-like model each new run needs access to the
-same intermediate data files, so we keep everything in an external
-data directory.
-
 
 ### Things to try
 

--- a/bin/fake-exe
+++ b/bin/fake-exe
@@ -15,7 +15,7 @@
 set -u
 
 EXE=$1
-TMP='.tmp o'
+TMP='.tmp'
 
 INPUT_FILES=$(ls $INPUT)
 if [[ -z "$INPUT_FILES" ]]; then

--- a/bin/skip
+++ b/bin/skip
@@ -33,7 +33,8 @@ import logging
 
 from iomodtimes import (
     outdated,
-    delete_files
+    delete_files,
+    file_globber
 )
 
 
@@ -52,6 +53,9 @@ if __name__ == "__main__":
         except KeyError:
             sys.stderr.write(__doc__)
             sys.exit(1)
+
+    if len(file_globber(input_globs)) == 0:
+        raise FileNotFoundError(input_globs)
 
     if not outdated(input_globs, output_globs):
         print("Output files are up to date.")


### PR DESCRIPTION
If /tmp/data/covid.raw did not exist, the pipeline would run successfully, simply skipping each step. Now, skip fails if the input isn't found.